### PR TITLE
Visualise basic client & sp metrics

### DIFF
--- a/src/data/client-stats.json.js
+++ b/src/data/client-stats.json.js
@@ -1,0 +1,19 @@
+
+import { query } from "./cloudflare-client.js";
+
+const response = await query(`
+  SELECT
+    client_address,
+    COUNT(*) AS total_requests,
+    SUM(CASE WHEN cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
+    SUM(egress_bytes) AS total_egress_bytes,
+    SUM(CASE WHEN cache_miss THEN egress_bytes ELSE 0 END) AS cache_miss_egress_bytes
+  FROM
+    retrieval_logs
+  GROUP BY
+    client_address
+  ORDER BY
+    total_requests DESC;
+`, [])
+
+process.stdout.write(JSON.stringify(response.result[0].results));

--- a/src/data/daily-egress.json.js
+++ b/src/data/daily-egress.json.js
@@ -3,11 +3,9 @@ import { query } from "./cloudflare-client.js";
 
 const response = await query(`SELECT
   DATE(timestamp) AS day,
-  sum(egress_bytes) AS total_egresss
+  ROUND(SUM(egress_bytes) / 1073741824.0, 2) AS total_egress_gib
 FROM
   retrieval_logs
-WHERE
-  timestamp >= DATE('now', '-30 days')
 GROUP BY
   day
 ORDER BY

--- a/src/data/daily-requests.json.js
+++ b/src/data/daily-requests.json.js
@@ -5,8 +5,6 @@ const response = await query(`SELECT
   COUNT(id) AS total_requests
 FROM
   retrieval_logs
-WHERE
-  timestamp >= DATE('now', '-30 days')
 GROUP BY
   day
 ORDER BY

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -1,0 +1,14 @@
+
+import { query } from "./cloudflare-client.js";
+
+const response = await query(`
+  SELECT
+    SUM(CASE WHEN cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
+    SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
+    SUM(egress_bytes) AS total_egress_bytes,
+    COUNT(*) AS total_requests
+  FROM
+    retrieval_logs;
+`, [])
+
+process.stdout.write(JSON.stringify(response.result[0].results[0]));

--- a/src/data/storage-provider-stats.json.js
+++ b/src/data/storage-provider-stats.json.js
@@ -1,0 +1,19 @@
+
+import { query } from "./cloudflare-client.js";
+
+const response = await query(`
+  SELECT
+    owner_address,
+    COUNT(*) AS total_requests,
+    SUM(CASE WHEN cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
+    SUM(egress_bytes) AS total_egress_bytes,
+    SUM(CASE WHEN cache_miss THEN egress_bytes ELSE 0 END) AS cache_miss_egress_bytes
+  FROM
+    retrieval_logs
+  GROUP BY
+    owner_address
+  ORDER BY
+    total_requests DESC;
+`, [])
+
+process.stdout.write(JSON.stringify(response.result[0].results));

--- a/src/index.md
+++ b/src/index.md
@@ -4,14 +4,35 @@ toc: false
 
 ```js
 import { LineGraph } from "./components/line-graph.js";
+import { formatBytesIEC } from "./utils/bytes.js"
+
+const PlatformStats = FileAttachment("./data/platform-stats.json").json();
 const DailyRequests = FileAttachment("./data/daily-requests.json").json();
 const DailyEgress = FileAttachment("./data/daily-egress.json").json();
+const StorageProviderStats = FileAttachment("./data/storage-provider-stats.json").json();
+const ClientStats = FileAttachment("./data/client-stats.json").json();
 ```
 
 <div class="hero">
   <body><a href="https://filcdn.com" target="_blank" rel="noopener noreferrer"><img src="media/filcdn-logo.png" alt="FilCDN Logo" width="300" /></a><body>
     <h2>FilCDN Dashboard</h2>
 </div>
+
+
+
+```js
+const cacheHitRate = PlatformStats.total_requests ? (PlatformStats.cache_hit_requests / PlatformStats.total_requests) * 100 : 0;
+```
+
+<h4>All time Stats</h4>
+
+<div class="grid grid-cols-3" style="grid-auto-rows: 100px;">
+    <h2 style="font-weight:normal;">Requests: ${PlatformStats.total_requests}</h2>
+    <h2 style="font-weight:normal;">Total Egress: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h2>
+    <h2 style="font-weight:normal;">Cache Hit Rate: ${cacheHitRate}%</h2>
+</div>
+
+<div class="divider"></div>
 
 <h4>Daily Stats</h4>
 
@@ -20,8 +41,57 @@ const DailyEgress = FileAttachment("./data/daily-egress.json").json();
     resize((width) => LineGraph(DailyRequests, {width, title: "Daily Requests", xKey: "day", yKey: "total_requests", label: "Daily Requests" }))
   }</div>
   <div class="card">${
-    resize((width) => LineGraph(DailyEgress, {width, title: "Daily Egress", xKey: "day", yKey: "total_egress", label: "Daily Egress" }))
+    resize((width) => LineGraph(DailyEgress, {width, title: "Daily Egress (GiB)", xKey: "day", yKey: "total_egress_gib", label: "Daily Egress (GiB)" }))
   }</div>
+</div>
+
+<div class="divider"></div>
+
+```js
+const spStats = Inputs.table(StorageProviderStats, {
+  rows: 16,
+  format: {
+    total_egress_bytes: (v) => formatBytesIEC(v),
+    cache_miss_egress_bytes: (v) => formatBytesIEC(v)
+  },
+  sort: {
+    total_egress_bytes: 'desc',
+  },
+  header: {
+    owner_address: "address",
+    total_egress_bytes: "total_egress",
+    cache_miss_egress_bytes: "cache_miss_egress"
+  }
+})
+```
+
+<h4>Storage Provider Stats</h4>
+<div class="card" style="padding: 0;">
+  ${spStats}
+</div>
+
+```js
+const clientStats = Inputs.table(ClientStats, {
+  rows: 16,
+  format: {
+    total_egress_bytes: (v) => formatBytesIEC(v),
+    cache_miss_egress_bytes: (v) => formatBytesIEC(v)
+  },
+  sort: {
+    total_egress_bytes: 'desc',
+  },
+  header: {
+    client_address: "address",
+    total_egress_bytes: "total_egress",
+    cache_miss_egress_bytes: "cache_miss_egress"
+  }
+})
+```
+
+<div class="divider"></div>
+<h4>Client Stats</h4>
+<div class="card" style="padding: 0;">
+  ${clientStats}
 </div>
 
 <style>
@@ -69,6 +139,10 @@ const DailyEgress = FileAttachment("./data/daily-egress.json").json();
 
 .hero img {
   max-width: 20%;
+}
+
+.divider {
+  margin: 50px;
 }
 
 @media (min-width: 640px) {

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -1,0 +1,9 @@
+export function formatBytesIEC(bytes) {
+  if (bytes === 0) return '0 B';
+
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+  const index = Math.floor(Math.log2(bytes) / 10);
+  const converted = bytes / Math.pow(2, index * 10);
+
+  return `${converted.toFixed(2)} ${units[index]}`;
+}


### PR DESCRIPTION
- Add all time platform stats: **total requests, total egress, cache hit rate**
- Change daily egress chart to display egress in GiB
- Add storage provider table and display following stats: **total requests, cache miss requests, total egress, cache miss egress**
- Add client table and display following stats: **total requests, cache miss requests, total egress, cache miss egress**

Related to https://github.com/filcdn/roadmap/issues/270