### PR TITLE
chore: add `.env` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 node_modules/
 yarn-error.log
+.env


### PR DESCRIPTION
I want to store the Cloudflare credentials in `.env` and don't want to accidentally commit them to git.
