### PR TITLE
feat: percentiles ttfb

### DIFF
--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -10,6 +10,7 @@ const response = await query(
 ),
 percentiles AS (
   SELECT
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 10) AS client_ttfb_p10,
     MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS client_ttfb_p50,
     MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS client_ttfb_p90,
     MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS client_ttfb_p99
@@ -20,6 +21,7 @@ SELECT
   SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
   SUM(egress_bytes) AS total_egress_bytes,
   COUNT(*) AS total_requests,
+  client_ttfb_p10,
   client_ttfb_p50,
   client_ttfb_p90,
   client_ttfb_p99

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -2,32 +2,32 @@ import { query } from './cloudflare-client.js'
 
 const response = await query(
   `
-  SELECT
-    SUM(CASE WHEN cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
-    SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
-    SUM(egress_bytes) AS total_egress_bytes,
-    COUNT(*) AS total_requests,
-  FROM
-    retrieval_logs;
-`,
-  [],
-)
-const result = response.result[0].results[0]
-
-const percentileResponse = await query(
-  `WITH ranked AS (
+  WITH ttfb_ranked AS (
   SELECT
     worker_ttfb,
     NTILE(100) OVER (ORDER BY worker_ttfb) AS percentile_rank
-  FROM your_table
+  FROM retrieval_logs
+),
+percentiles AS (
+  SELECT
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS p50_worker_ttfb,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90_worker_ttfb,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99_worker_ttfb
+  FROM ttfb_ranked
 )
 SELECT
-  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS p50,
-  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90,
-  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99;`,
+  SUM(CASE WHEN cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
+  SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
+  SUM(egress_bytes) AS total_egress_bytes,
+  COUNT(*) AS total_requests,
+  p50_worker_ttfb,
+  p90_worker_ttfb,
+  p99_worker_ttfb
+FROM
+  retrieval_logs,
+  percentiles;
+`,
+  [],
 )
-result.p50_worker_ttfb = percentileResponse.result[0].results[0].p50
-result.p90_worker_ttfb = percentileResponse.result[0].results[0].p90
-result.p99_worker_ttfb = percentileResponse.result[0].results[0].p99
 
-process.stdout.write(JSON.stringify(result))
+process.stdout.write(JSON.stringify(response.result[0].results[0]))

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -10,9 +10,9 @@ const response = await query(
 ),
 percentiles AS (
   SELECT
-    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS p50_worker_ttfb,
-    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90_worker_ttfb,
-    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99_worker_ttfb
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS client_ttfb_p50,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS client_ttfb_p90,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS client_ttfb_p99
   FROM ttfb_ranked
 )
 SELECT
@@ -20,9 +20,9 @@ SELECT
   SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
   SUM(egress_bytes) AS total_egress_bytes,
   COUNT(*) AS total_requests,
-  p50_worker_ttfb,
-  p90_worker_ttfb,
-  p99_worker_ttfb
+  client_ttfb_p50,
+  client_ttfb_p90,
+  client_ttfb_p99
 FROM
   retrieval_logs,
   percentiles;

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -14,4 +14,21 @@ const response = await query(
   [],
 )
 
-process.stdout.write(JSON.stringify(response.result[0].results[0]))
+const percentileResponse = await query(
+`WITH ranked AS (
+  SELECT
+    worker_ttfb,
+    NTILE(100) OVER (ORDER BY worker_ttfb) AS percentile_rank
+  FROM your_table
+)
+SELECT
+  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS p50,
+  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90,
+  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99;`
+)
+const result = response.result[0].results[0]
+result.p50_worker_ttfb = percentileResponse.result[0].results[0].p50
+result.p90_worker_ttfb = percentileResponse.result[0].results[0].p90
+result.p99_worker_ttfb = percentileResponse.result[0].results[0].p99
+
+process.stdout.write(JSON.stringify(result))

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -7,12 +7,12 @@ const response = await query(
     SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
     SUM(egress_bytes) AS total_egress_bytes,
     COUNT(*) AS total_requests,
-    AVG(worker_ttfb) AS avg_client_ttfb
   FROM
     retrieval_logs;
 `,
   [],
 )
+const result = response.result[0].results[0]
 
 const percentileResponse = await query(
   `WITH ranked AS (
@@ -26,7 +26,6 @@ SELECT
   MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90,
   MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99;`,
 )
-const result = response.result[0].results[0]
 result.p50_worker_ttfb = percentileResponse.result[0].results[0].p50
 result.p90_worker_ttfb = percentileResponse.result[0].results[0].p90
 result.p99_worker_ttfb = percentileResponse.result[0].results[0].p99

--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -15,7 +15,7 @@ const response = await query(
 )
 
 const percentileResponse = await query(
-`WITH ranked AS (
+  `WITH ranked AS (
   SELECT
     worker_ttfb,
     NTILE(100) OVER (ORDER BY worker_ttfb) AS percentile_rank
@@ -24,7 +24,7 @@ const percentileResponse = await query(
 SELECT
   MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS p50,
   MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS p90,
-  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99;`
+  MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS p99;`,
 )
 const result = response.result[0].results[0]
 result.p50_worker_ttfb = percentileResponse.result[0].results[0].p50

--- a/src/index.md
+++ b/src/index.md
@@ -49,6 +49,7 @@ const cacheHitRate = PlatformStats.total_requests
   <div class="flex flex-col items-center">
     <h4 class="font-normal">Client TTFB (ms)</h4>
     <div class="text-sm text-center">
+      <div>P10: ${PlatformStats.client_ttfb_p10?.toFixed(2) ?? 'N/A'}</div>
       <div>P50: ${PlatformStats.client_ttfb_p50?.toFixed(2) ?? 'N/A'}</div>
       <div>P90: ${PlatformStats.client_ttfb_p90?.toFixed(2) ?? 'N/A'}</div>
       <div>P99: ${PlatformStats.client_ttfb_p99?.toFixed(2) ?? 'N/A'}</div>

--- a/src/index.md
+++ b/src/index.md
@@ -46,7 +46,12 @@ const cacheHitRate = PlatformStats.total_requests
     <h4 style="font-weight:normal;">Requests Served: ${PlatformStats.total_requests}</h4>
     <h4 style="font-weight:normal;">Bytes Served: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h4>
     <h4 style="font-weight:normal;">Cache Hit Rate: ${cacheHitRate}%</h4>
-    <h4 style="font-weight:normal;">Average Client TTFB: ${PlatformStats.avg_client_ttfb.toFixed(2) ?? 0} ms</h4>
+    <h4 style="font-weight:normal;">
+        Client TTFB (ms): 
+        P50: ${PlatformStats.client_ttfb_p50.toFixed(2) ?? 0}, 
+        P90: ${PlatformStats.client_ttfb_p90.toFixed(2) ?? 0}, 
+        P99: ${PlatformStats.client_ttfb_p99.toFixed(2) ?? 0}
+    </h4>
 </div>
 
 <div class="divider"></div>

--- a/src/index.md
+++ b/src/index.md
@@ -43,15 +43,17 @@ const cacheHitRate = PlatformStats.total_requests
 <h4>All time Stats</h4>
 
 <div class="grid grid-cols-4">
-    <h4 style="font-weight:normal;">Requests Served: ${PlatformStats.total_requests}</h4>
-    <h4 style="font-weight:normal;">Bytes Served: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h4>
-    <h4 style="font-weight:normal;">Cache Hit Rate: ${cacheHitRate}%</h4>
-    <h4 style="font-weight:normal;">
-        Client TTFB (ms): 
-        P50: ${PlatformStats.client_ttfb_p50.toFixed(2) ?? 0}, 
-        P90: ${PlatformStats.client_ttfb_p90.toFixed(2) ?? 0}, 
-        P99: ${PlatformStats.client_ttfb_p99.toFixed(2) ?? 0}
-    </h4>
+  <h4 class="font-normal">Requests Served: ${PlatformStats.total_requests}</h4>
+  <h4 class="font-normal">Bytes Served: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h4>
+  <h4 class="font-normal">Cache Hit Rate: ${cacheHitRate}%</h4>
+  <div class="flex flex-col items-center">
+    <h4 class="font-normal">Client TTFB (ms)</h4>
+    <div class="text-sm text-center">
+      <div>P50: ${PlatformStats.client_ttfb_p50?.toFixed(2) ?? 'N/A'}</div>
+      <div>P90: ${PlatformStats.client_ttfb_p90?.toFixed(2) ?? 'N/A'}</div>
+      <div>P99: ${PlatformStats.client_ttfb_p99?.toFixed(2) ?? 'N/A'}</div>
+    </div>
+  </div>
 </div>
 
 <div class="divider"></div>


### PR DESCRIPTION
This PR removes the average ttfb from the dashboard view and replaces it with 50, 90 and 99 percentiles for a more accurate display of the ttfb response times. 