### PR TITLE
feat: display p95 latency + other tweaks

### DIFF
--- a/src/data/platform-stats.json.js
+++ b/src/data/platform-stats.json.js
@@ -10,9 +10,9 @@ const response = await query(
 ),
 percentiles AS (
   SELECT
-    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 10) AS worker_ttfb_p10,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 5) AS worker_ttfb_p5,
     MIN(worker_ttfb) FILTER (WHERE percentile_rank = 50) AS worker_ttfb_p50,
-    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 90) AS worker_ttfb_p90,
+    MIN(worker_ttfb) FILTER (WHERE percentile_rank = 95) AS worker_ttfb_p95,
     MIN(worker_ttfb) FILTER (WHERE percentile_rank = 99) AS worker_ttfb_p99
   FROM ttfb_ranked
 )
@@ -21,9 +21,9 @@ SELECT
   SUM(CASE WHEN NOT cache_miss THEN 1 ELSE 0 END) AS cache_hit_requests,
   SUM(egress_bytes) AS total_egress_bytes,
   COUNT(*) AS total_requests,
-  worker_ttfb_p10,
+  worker_ttfb_p5,
   worker_ttfb_p50,
-  worker_ttfb_p90,
+  worker_ttfb_p95,
   worker_ttfb_p99
 FROM
   retrieval_logs,

--- a/src/index.md
+++ b/src/index.md
@@ -42,18 +42,33 @@ const cacheHitRate = PlatformStats.total_requests
 
 <h4>All time Stats</h4>
 
+```js
+const workerLatency = Inputs.table(
+  [5, 50, 95, 99].map((percentile) => ({
+    percentile: `p${percentile}`,
+    ttfb: PlatformStats[`worker_ttfb_p${percentile}`],
+  })),
+  {
+    layout: 'auto',
+    format: {
+      ttfb: (v) => v.toFixed(2) ?? 'N/A',
+    },
+    header: {
+      percentile: 'Percentile',
+      ttfb: 'TTFB (ms)',
+    },
+  },
+)
+```
+
 <div class="grid grid-cols-4">
   <h4 class="font-normal">Requests Served: ${PlatformStats.total_requests}</h4>
   <h4 class="font-normal">Bytes Served: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h4>
   <h4 class="font-normal">Cache Hit Rate: ${cacheHitRate}%</h4>
   <div class="flex flex-col items-center">
-    <h4 class="font-normal">Worker TTFB (ms)</h4>
-    <div class="text-sm text-center">
-      <div>P10: ${PlatformStats.worker_ttfb_p10?.toFixed(2) ?? 'N/A'}</div>
-      <div>P50: ${PlatformStats.worker_ttfb_p50?.toFixed(2) ?? 'N/A'}</div>
-      <div>P90: ${PlatformStats.worker_ttfb_p90?.toFixed(2) ?? 'N/A'}</div>
-      <div>P99: ${PlatformStats.worker_ttfb_p99?.toFixed(2) ?? 'N/A'}</div>
-    </div>
+    <h4 class="font-normal">Worker Latency</h4>
+    <p>(Time to send the first byte to the client)</p>
+    <div class="card" style="padding: 0;">${workerLatency}</div>
   </div>
 </div>
 

--- a/src/index.md
+++ b/src/index.md
@@ -61,7 +61,7 @@ const workerLatency = Inputs.table(
 )
 ```
 
-<div class="grid grid-cols-4">
+<div class="grid grid-cols-3">
   <div class="flex flex-col items-center">
     <h4 class="font-normal">Requests Served</h4>
     <div class="card card-figure">${PlatformStats.total_requests}</div>
@@ -74,11 +74,11 @@ const workerLatency = Inputs.table(
     <h4 class="font-normal">Cache Hit Rate</h4>
     <div class="card card-figure">${cacheHitRate}%</div>
   </div>
+</div>
+
+<div class="grid grid-cols-3">
   <div class="flex flex-col items-center">
-    <h4 class="font-normal">
-      Worker Latency
-      <span class="tooltip" data-tooltip="Time to send the first byte to the client."></span>
-    </h4>
+    <h4 class="font-normal">Worker Response Time</h4>
     <div class="card" style="padding: 0;">${workerLatency}</div>
   </div>
 </div>
@@ -306,46 +306,6 @@ const clientStats = Inputs.table(ClientStats, {
   .hero h1 {
     font-size: 90px;
   }
-}
-
-.tooltip {
-  position:relative; /* making the .tooltip span a container for the tooltip text */
-}
-
-.tooltip:after {
-  content: " ?⃝";
-}
-
-.tooltip:before {
-  content: attr(data-tooltip);
-  position: absolute;
-  z-index: 100;
-
-  /* vertically center */
-  top: 50%;
-  transform: translateY(-100%);
-
-  /* move to right */
-  left: 100%;
-  margin-left: 5px; /* and add a small left margin */
-
-  /* basic styles */
-  width: 200px;
-  padding: 1em;
-  border-radius: 0.75rem;
-  background: var(--theme-background-alt);
-  color: var(--theme-foreground);
-  border: solid 1px var(--theme-foreground-muted);
-  font-weight: normal;
-  font-size: 0.75rem;
-  text-align: left;
-  text-wrap: wrap;
-
-  display: none; /* hide by default */
-}
-
-.tooltip:hover:before {
-  display:block;
 }
 
 </style>

--- a/src/index.md
+++ b/src/index.md
@@ -62,12 +62,23 @@ const workerLatency = Inputs.table(
 ```
 
 <div class="grid grid-cols-4">
-  <h4 class="font-normal">Requests Served: ${PlatformStats.total_requests}</h4>
-  <h4 class="font-normal">Bytes Served: ${formatBytesIEC(PlatformStats.total_egress_bytes)}</h4>
-  <h4 class="font-normal">Cache Hit Rate: ${cacheHitRate}%</h4>
   <div class="flex flex-col items-center">
-    <h4 class="font-normal">Worker Latency</h4>
-    <p>(Time to send the first byte to the client)</p>
+    <h4 class="font-normal">Requests Served</h4>
+    <div class="card card-figure">${PlatformStats.total_requests}</div>
+  </div>
+  <div class="flex flex-col items-center">
+    <h4 class="font-normal">Bytes Served</h4>
+    <div class="card card-figure">${formatBytesIEC(PlatformStats.total_egress_bytes)}</div>
+  </div>
+  <div class="flex flex-col items-center">
+    <h4 class="font-normal">Cache Hit Rate</h4>
+    <div class="card card-figure">${cacheHitRate}%</div>
+  </div>
+  <div class="flex flex-col items-center">
+    <h4 class="font-normal">
+      Worker Latency
+      <span class="tooltip" data-tooltip="Time to send the first byte to the client."></span>
+    </h4>
     <div class="card" style="padding: 0;">${workerLatency}</div>
   </div>
 </div>
@@ -246,7 +257,7 @@ const clientStats = Inputs.table(ClientStats, {
   flex-direction: column;
   align-items: center;
   padding: 1rem 0;
-  font-size: 4vw;
+  font-size: 3vw;
   color: #E30ADA;
 }
 
@@ -295,6 +306,46 @@ const clientStats = Inputs.table(ClientStats, {
   .hero h1 {
     font-size: 90px;
   }
+}
+
+.tooltip {
+  position:relative; /* making the .tooltip span a container for the tooltip text */
+}
+
+.tooltip:after {
+  content: " ?⃝";
+}
+
+.tooltip:before {
+  content: attr(data-tooltip);
+  position: absolute;
+  z-index: 100;
+
+  /* vertically center */
+  top: 50%;
+  transform: translateY(-100%);
+
+  /* move to right */
+  left: 100%;
+  margin-left: 5px; /* and add a small left margin */
+
+  /* basic styles */
+  width: 200px;
+  padding: 1em;
+  border-radius: 0.75rem;
+  background: var(--theme-background-alt);
+  color: var(--theme-foreground);
+  border: solid 1px var(--theme-foreground-muted);
+  font-weight: normal;
+  font-size: 0.75rem;
+  text-align: left;
+  text-wrap: wrap;
+
+  display: none; /* hide by default */
+}
+
+.tooltip:hover:before {
+  display:block;
 }
 
 </style>

--- a/src/index.md
+++ b/src/index.md
@@ -40,7 +40,7 @@ const cacheHitRate = PlatformStats.total_requests
   : 0
 ```
 
-<h4>All time Stats</h4>
+<h2>All time Stats</h2>
 
 ```js
 const workerLatency = Inputs.table(
@@ -85,7 +85,7 @@ const workerLatency = Inputs.table(
 
 <div class="divider"></div>
 
-<h4>Daily Stats</h4>
+<h2>Daily Stats</h2>
 
 <div class="grid grid-cols-2" style="grid-auto-rows: 500px;">
   <div class="card">${
@@ -221,7 +221,7 @@ const spStats = Inputs.table(StorageProviderStats, {
 ```
 
 <div class="divider"></div>
-<h4>Storage Provider Stats</h4>
+<h2>Storage Provider Stats</h2>
 <div class="card" style="padding: 0;">
   ${spStats}
 </div>
@@ -246,7 +246,7 @@ const clientStats = Inputs.table(ClientStats, {
 ```
 
 <div class="divider"></div>
-<h4>Client Stats</h4>
+<h2>Client Stats</h2>
 <div class="card" style="padding: 0;">
   ${clientStats}
 </div>


### PR DESCRIPTION
- Rename the section to "Worker Latency", add explanation of what this means.
- Format the latencies as a table inside a card for consistency with other tables.
- Rework the percentiles shown to p5, p50, p95 and p99.
- Use cards and tooltips in all-time stats

---

**Before:**

<img width="1427" height="493" alt="Screenshot 2025-08-05 at 10 31 55" src="https://github.com/user-attachments/assets/e7bddd27-1d84-47db-883e-febd45130c15" />

---

**After:**

<img width="1473" height="733" alt="Screenshot 2025-08-06 at 11 44 05" src="https://github.com/user-attachments/assets/47170acb-d2a9-4252-8157-065a4e9d4382" />
