### PR TITLE
fix: hide current day data from daily charts

### DIFF
--- a/src/data/[client]-daily-stats.json.js
+++ b/src/data/[client]-daily-stats.json.js
@@ -19,7 +19,8 @@ const response = await query(
   FROM
     retrieval_logs
   WHERE
-    client_address = $1
+    client_address = $1 AND
+    DATE(timestamp) < DATE('now')
   GROUP BY
     day, client_address
   ORDER BY

--- a/src/data/[client]-proof-set-stats.json.js
+++ b/src/data/[client]-proof-set-stats.json.js
@@ -20,7 +20,8 @@ const response = await query(
   LEFT JOIN
     retrieval_logs rl ON rl.proof_set_id = ipr.proof_set_id
   WHERE
-    payer = $1 AND with_cdn = true
+      payer = $1 AND with_cdn = true AND
+    (rl.timestamp IS NULL OR DATE(rl.timestamp) < DATE('now'))
   GROUP BY
     ipr.proof_set_id
   ORDER BY

--- a/src/data/daily-egress.json.js
+++ b/src/data/daily-egress.json.js
@@ -6,6 +6,8 @@ const response = await query(
   ROUND(SUM(egress_bytes) / 1073741824.0, 2) AS total_egress_gib
 FROM
   retrieval_logs
+WHERE
+  DATE(timestamp) < DATE('now')
 GROUP BY
   day
 ORDER BY

--- a/src/data/daily-requests.json.js
+++ b/src/data/daily-requests.json.js
@@ -6,6 +6,8 @@ const response = await query(
   COUNT(id) AS total_requests
 FROM
   retrieval_logs
+WHERE
+  DATE(timestamp) < DATE('now')
 GROUP BY
   day
 ORDER BY

--- a/src/data/daily-retrieval-speed.json.js
+++ b/src/data/daily-retrieval-speed.json.js
@@ -10,7 +10,8 @@ WITH retrieval_speeds AS (
         retrieval_logs
     WHERE
         cache_miss = 1 AND
-        fetch_ttlb > 0
+        fetch_ttlb > 0 AND
+        DATE(timestamp) < DATE('now')
 ),
 percentile_buckets AS (
   SELECT 

--- a/src/data/response-code-breakdown.json.js
+++ b/src/data/response-code-breakdown.json.js
@@ -8,6 +8,8 @@ WITH daily_totals AS (
     COUNT(*) AS total_requests
   FROM
     retrieval_logs
+  WHERE
+    DATE(timestamp) < DATE('now')
   GROUP BY
     day
 )
@@ -18,6 +20,8 @@ SELECT
 FROM
   retrieval_logs r
   JOIN daily_totals dt ON DATE(r.timestamp) = dt.day
+WHERE
+  DATE(r.timestamp) < DATE('now')
 GROUP BY
   day,
   code


### PR DESCRIPTION
## Issue
Currently, all daily charts include today's current data, which is incomplete and makes the charts look misleading. Users see partial data for the current day that can give wrong impressions about trends and performance.

## Solution
Add filter to daily data queries to ensure only fully completed days are displayed in charts.

## Changes Made
- **daily-requests.json.js**: Filter out current day from daily request counts
- **daily-egress.json.js**: Filter out current day from daily egress data  
- **daily-retrieval-speed.json.js**: Filter out current day from daily retrieval speed metrics
-  **response-code-breakdown.json.js**: Filter out current day from daily response codes
- **[client]-daily-stats.json.js**: Filter out current day from client-specific daily statistics
- **[client]-proof-set-stats.json.js**: Filter out current day from client proof set statistics

## Impact
- **Dashboard Homepage**: Daily Requests, Daily Egress (GiB), and Daily Retrieval Speeds charts now show only complete data
- **Client Pages**: Individual client daily stats and proof set stats exclude current day data
- **Data Quality**: All charts now display consistent, complete daily data without misleading partial information.

Closes #16