### PR TITLE
fix: client stats overview query

### DIFF
--- a/src/data/client-stats.json.js
+++ b/src/data/client-stats.json.js
@@ -2,24 +2,42 @@ import { query } from './cloudflare-client.js'
 
 const response = await query(
   `
+  WITH client_stats AS (
+    SELECT
+      cs.payer_address,
+      COUNT(rl.id) AS total_requests,
+      SUM(CASE WHEN rl.cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
+      SUM(rl.egress_bytes) AS total_egress_bytes,
+      SUM(CASE WHEN rl.cache_miss THEN rl.egress_bytes ELSE 0 END) AS cache_miss_egress_bytes
+    FROM
+      retrieval_logs rl
+    JOIN
+      data_sets cs ON cs.id = rl.data_set_id
+    GROUP BY
+      cs.payer_address
+  ),
+  client_quotas AS (
+    SELECT
+      cs.payer_address,
+      SUM(cseqs.cdn_egress_quota) AS remaining_cdn_egress_bytes,
+      SUM(cseqs.cache_miss_egress_quota) AS remaining_cache_miss_egress_bytes
+    FROM
+      data_sets cs
+    JOIN
+      data_set_egress_quotas cseqs ON cs.id = cseqs.data_set_id
+    GROUP BY
+      cs.payer_address
+  )
   SELECT
-    ds.payer_address,
-    COUNT(*) AS total_requests,
-    SUM(CASE WHEN rl.cache_miss THEN 1 ELSE 0 END) AS cache_miss_requests,
-    SUM(rl.egress_bytes) AS total_egress_bytes,
-    SUM(CASE WHEN rl.cache_miss THEN egress_bytes ELSE 0 END) AS cache_miss_egress_bytes,
-    SUM(dseqs.cdn_egress_quota) AS remaining_cdn_egress_bytes,
-    SUM(dseqs.cache_miss_egress_quota) AS remaining_cache_miss_egress_bytes
+    cs.*,
+    cq.remaining_cdn_egress_bytes,
+    cq.remaining_cache_miss_egress_bytes
   FROM
-    retrieval_logs rl
-  JOIN
-    data_sets ds ON ds.id = rl.data_set_id
-  JOIN
-    data_set_egress_quotas dseqs ON ds.id = dseqs.data_set_id
-  GROUP BY
-    ds.payer_address
+    client_stats cs
+  LEFT JOIN
+    client_quotas cq ON cs.payer_address = cq.payer_address
   ORDER BY
-    total_requests DESC;
+    cs.total_requests DESC;
 `,
   [],
 )

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -1,9 +1,13 @@
 export function formatBytesIEC(bytes) {
   if (bytes === 0) return '0 B'
 
-  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
-  const index = Math.floor(Math.log2(bytes) / 10)
-  const converted = bytes / Math.pow(2, index * 10)
+  const isNegative = bytes < 0
+  const absoluteBytes = Math.abs(bytes)
 
-  return `${converted.toFixed(2)} ${units[index]}`
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+  const index = Math.floor(Math.log2(absoluteBytes) / 10)
+  const converted = absoluteBytes / Math.pow(2, index * 10)
+
+  const formatted = `${converted.toFixed(2)} ${units[index]}`
+  return isNegative ? `-${formatted}` : formatted
 }

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -3,7 +3,7 @@ export function formatBytesIEC(bytes) {
 
   const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
   const index = Math.floor(Math.log2(Math.abs(bytes)) / 10)
-  const converted = Math.abs(bytes) / Math.pow(2, index * 10)
+  const converted = bytes / Math.pow(2, index * 10)
 
-  return `${bytes < 0 ? '-' : ''}${converted.toFixed(2)} ${units[index]}`
+  return `${converted.toFixed(2)} ${units[index]}`
 }

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -1,13 +1,9 @@
 export function formatBytesIEC(bytes) {
   if (bytes === 0) return '0 B'
 
-  const isNegative = bytes < 0
-  const absoluteBytes = Math.abs(bytes)
-
   const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
-  const index = Math.floor(Math.log2(absoluteBytes) / 10)
-  const converted = absoluteBytes / Math.pow(2, index * 10)
+  const index = Math.floor(Math.log2(Math.abs(bytes)) / 10)
+  const converted = Math.abs(bytes) / Math.pow(2, index * 10)
 
-  const formatted = `${converted.toFixed(2)} ${units[index]}`
-  return isNegative ? `-${formatted}` : formatted
+  return `${bytes < 0 ? '-' : ''}${converted.toFixed(2)} ${units[index]}`
 }


### PR DESCRIPTION
- Split client stats queries into two subqueries
- Fix formatBytesIEC to support negative numbers

Old query was joining `data_set_egress_quotas` for every row found in the `retrieval_logs` table, leading to incorrect client stats. New query uses two subqueries -- one that aggregates retrieval stats based on the `retrieval_logs` table and the second subquery that aggregates egress data by payer (client).

Mainnet query now returns 175.52 GiB for @juliangruber address instead of the 9TiB previously. 